### PR TITLE
feat: add the `hb.toc_scrollspy.border` parameter, default to `true`

### DIFF
--- a/assets/hb/modules/toc-scrollspy/scss/index.scss
+++ b/assets/hb/modules/toc-scrollspy/scss/index.scss
@@ -1,7 +1,21 @@
 #TableOfContents {
     a {
+        @if ($hb-toc-scrollspy-border) {
+            padding-left: .5rem;
+            margin-left: -.5rem;
+        }
+
         &.active {
             color: var(--#{$prefix}primary);
+
+            @if ($hb-toc-scrollspy-border) {
+                @extend .border-start;
+                @extend .border-primary;
+
+                --#{$prefix}border-width: .125rem;
+
+                padding-left: calc(.5rem - .125rem);
+            }
         }
     }
 }

--- a/assets/hb/modules/toc-scrollspy/scss/variables.tmpl.scss
+++ b/assets/hb/modules/toc-scrollspy/scss/variables.tmpl.scss
@@ -1,0 +1,1 @@
+$hb-toc-scrollspy-border: {{ default true site.Params.hb.toc_scrollspy.border }};

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,4 +4,5 @@
 [[module.imports]]
 path = "github.com/hbstack/hb"
 
-# [params.hb.toc_scrollspy]
+[params.hb.toc_scrollspy]
+border = true


### PR DESCRIPTION
Show the left border on active item if `true`

![hb-toc-scrollspy-border](https://github.com/user-attachments/assets/9123a5d7-2281-4d23-9482-b395249f0341)
